### PR TITLE
Fix issue with values returned as Timedeltas

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ Changes:
 
 Fixes:
 
+- Issue when values returned from ERDDAP as Timedelta rather than a float.
+
 ## 0.1.1 - 9/4/19
 
 Changes:

--- a/app/deployments/tasks.py
+++ b/app/deployments/tasks.py
@@ -2,6 +2,7 @@ import logging
 
 from celery import shared_task
 from requests import HTTPError
+from pandas import Timedelta
 
 from deployments.models import ErddapDataset, ErddapServer
 from deployments.utils.erddap_datasets import filter_dataframe, retrieve_dataframe
@@ -37,7 +38,13 @@ def update_values_for_timeseries(timeseries):
                 logger.warning(message)
             else:
                 try:
-                    series.value = row[series.variable]
+                    value = row[series.variable]
+
+                    if isinstance(value, Timedelta):
+                        logger.info("Converting from Timedelta to seconds")
+                        value = value.seconds
+
+                    series.value = value
                     series.value_time = row["time"].to_pydatetime()
                     series.save()
                 except TypeError as error:

--- a/k8s/base/worker.yaml
+++ b/k8s/base/worker.yaml
@@ -15,7 +15,7 @@ spec:
         role: worker
     spec:
       containers:
-        - name: web
+        - name: worker
           image: gmri/neracoos-buoy-barn
           args:
             - celery


### PR DESCRIPTION
With a change of wave periods to be returned in seconds rather than frequency by NERACOOS ERDDAP, those values were being passed to the database as `Timedelta` which cannot be natively stored as a float and throwing an error.

Instead we are extracting seconds and storing that.

[Sentry issue](https://sentry.io/organizations/gulf-of-maine-research-institu/issues/1206549203/?cursor=0%3A100%3A0&project=1373247&statsPeriod=14d)
[ClickUp task](https://app.clickup.com/t/1wakru)