### PR TITLE
Skip time series that do not have constraints and alert on error

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ Changes:
 
 Fixes:
 
+- Issue where constraints are not set blocks whole server from updating
+
 ## 0.1.2 - 9/4/19
 
 Fixes:

--- a/app/deployments/models.py
+++ b/app/deployments/models.py
@@ -264,7 +264,10 @@ class ErddapDataset(models.Model):
         groups = defaultdict(list)
 
         for ts in self.timeseries_set.filter(end_time=None):
-            groups[tuple(ts.constraints.items())].append(ts)
+            try:
+                groups[tuple(ts.constraints.items())].append(ts)
+            except AttributeError as e:
+                logger.error(f"Unable to set constraint for timeseries {ts} due to {e}")
 
         return groups
 


### PR DESCRIPTION
When time series for platforms are missing a constraint (instead of having `{}` for an empty constraint) the data updating task fails.

Now that [error](https://sentry.io/organizations/gulf-of-maine-research-institu/issues/1411884425/?project=1373247&query=is%3Aunresolved) will be caught and sent to Sentry with some info, but the task should finish.