### PR TITLE
Fix better error handling for HTTPErrors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ Changes:
 
 Fixes:
 
+- 403 Blacklist error was being caught as a warning.
+
 ## 0.1.5 - 4/7/2020
 
 Changes:


### PR DESCRIPTION
Coastwatch was returning 403 errors due to being added to the blacklist. We were catching all `HTTPErrors` and treating them the same (as if there is no valid data).

Now we are separating out different types of `HTTPErrors` and logging them separately.