### PR TITLE
Include timezone in forecast datetime so that browsers don't guess

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ Changes:
 
 Fixes:
 
+- Include `Z` on the end of forecast dates to specify the timezone so that browsers don't guess.
+
 ## 0.1.15 - 12/15/2020
 
 Changes:

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ shell:
 	docker-compose exec web python manage.py shell
 
 test:
-	docker-compose exec -e DJANGO_ENV=test  web pytest --cov=. --cov-config=tox.ini
+	docker-compose run -e DJANGO_ENV=test web pytest --cov=. --cov-config=tox.ini
 
 test-debug:
-	docker-compose exec -e DJANGO_ENV=test web pytest --cov=. --cov-config=tox.ini -v --pdb --log-cli-level=INFO
+	docker-compose run -e DJANGO_ENV=test web pytest --cov=. --cov-config=tox.ini -v --pdb --log-cli-level=INFO
 
 coverage:
 	docker-compose exec web coverage run --source='.' manage.py test

--- a/app/forecasts/views.py
+++ b/app/forecasts/views.py
@@ -1,4 +1,5 @@
 """Viewset for displaying forecasts, and fetching point forecast data is lat,lon are specified"""
+from datetime import timezone
 from json import JSONDecodeError
 import logging
 
@@ -57,7 +58,8 @@ class ForecastViewSet(viewsets.ViewSet):
                 )
 
             data["time_series"] = [
-                {"time": reading[0], "reading": reading[1]} for reading in time_series
+                {"time": time.replace(tzinfo=timezone.utc), "reading": reading}
+                for time, reading in time_series
             ]
 
         else:


### PR DESCRIPTION
When Mariner's dashboard tries to guess the datetime, in some browsers it uses local timezone instead of UTC which leads to:

![image](https://user-images.githubusercontent.com/1296209/107421161-a13c3800-6ae7-11eb-9a9a-1cefdee21532.png)

Instead of:

![image](https://user-images.githubusercontent.com/1296209/107421181-a6998280-6ae7-11eb-84fd-ab64c07070d6.png)


Closes #291 gulfofmaine/NERACOOS-operations#3