### PR TITLE
Reduce the secrets needed to test forks (like Dependabot)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,27 +76,16 @@ jobs:
           docker load --input /tmp/myimage.tar
           docker image ls -a
 
-      - name: Setup Docker Data
-        run: |
-          mkdir docker-data
-          cat <<< "${{ secrets.DOCKER_DATA_SECRET }}" > docker-data/secret.env
-
-      - name: Bring up server
-        run: docker-compose up -d
-
-      - name: Wait for database to be ready
-        run: docker-compose run web python manage.py db_ready
-
       - name: Test
-        run: docker-compose run -e DJANGO_ENV=test web pytest --cov=. --cov-config=tox.ini --cov-report=xml:./coverage.xml
+        run: make test
 
-      - name: Install Codacy coverage reporter
-        run: pip install --user codacy-coverage
-
-      - name: Send coverage to Codacy
-        run: ~/.local/bin/python-codacy-coverage -r app/coverage.xml
+      - name: Send coverage to Codacy (skip coverage if no project token secret)
+        run: |
+          pip install --user codacy-coverage
+          ~/.local/bin/python-codacy-coverage -r app/coverage.xml
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        if: env.CODACY_PROJECT_TOKEN != null
 
   deploy:
     name: Build and Push tagged image to Docker Hub, and update Argo config

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ Changes:
 
 Fixes:
 
+- Reduce need to access secrets during testing to reduce problems with PRs from forks. See [1](https://github.community/t/dependabot-prs-and-workflow-secrets/163269/23) [2](https://github.community/t/dependabot-doesnt-see-github-actions-secrets/167104/25)
+
 ## 0.3.4 - 03/17/2021
 
 Fixes:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ shell:
 	docker-compose exec web python manage.py shell
 
 test:
-	docker-compose -f docker-compose.test.yaml run -e DJANGO_ENV=test web pytest --cov=. --cov-config=tox.ini
+	docker-compose -f docker-compose.test.yaml run -e DJANGO_ENV=test web pytest --cov=. --cov-config=tox.ini --cov-report=xml:./coverage.xml
 
 test-debug:
 	docker-compose run -e DJANGO_ENV=test web pytest --cov=. --cov-config=tox.ini -v --pdb --log-cli-level=INFO

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ shell:
 	docker-compose exec web python manage.py shell
 
 test:
-	docker-compose run -e DJANGO_ENV=test web pytest --cov=. --cov-config=tox.ini
+	docker-compose -f docker-compose.test.yaml run -e DJANGO_ENV=test web pytest --cov=. --cov-config=tox.ini
 
 test-debug:
 	docker-compose run -e DJANGO_ENV=test web pytest --cov=. --cov-config=tox.ini -v --pdb --log-cli-level=INFO

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,0 +1,30 @@
+version: "3.7"
+
+services:
+  db: 
+    image: mdillon/postgis:10-alpine@sha256:41516e866f9ec84a7c348084e02b577961cc5bca7c827d91b4566f0f729f370c
+    env_file:
+      - ./docker-data/test.env
+    # ports:
+    #   - "5432:5432"
+
+  cache:
+    image: redis:5.0.3-alpine@sha256:f8c22abc77f3f9cc1c2516062e4a2a71375859d7922da3faf9e4160e6ba4c3c2
+
+  web:
+    build: ./app
+    image: gmri/neracoos-buoy-barn
+    # volumes:
+      # - ./app:/app
+      # - ./.prospector.yaml:/app/.prospector.yaml
+      # - ./docker-data/django-static:/static
+    # ports:
+    #   - "8080:8080"
+    # environment:
+      # DJANGO_MANAGEPY_COLLECTSTATIC: "on"
+      # PREFECT_PROJECT_NAME: buoy-barn-dev
+    env_file:
+      - ./docker-data/test.env
+    links:
+      - db
+      - cache

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -5,8 +5,6 @@ services:
     image: mdillon/postgis:10-alpine@sha256:41516e866f9ec84a7c348084e02b577961cc5bca7c827d91b4566f0f729f370c
     env_file:
       - ./docker-data/test.env
-    # ports:
-    #   - "5432:5432"
 
   cache:
     image: redis:5.0.3-alpine@sha256:f8c22abc77f3f9cc1c2516062e4a2a71375859d7922da3faf9e4160e6ba4c3c2
@@ -14,15 +12,8 @@ services:
   web:
     build: ./app
     image: gmri/neracoos-buoy-barn
-    # volumes:
-      # - ./app:/app
-      # - ./.prospector.yaml:/app/.prospector.yaml
-      # - ./docker-data/django-static:/static
-    # ports:
-    #   - "8080:8080"
-    # environment:
-      # DJANGO_MANAGEPY_COLLECTSTATIC: "on"
-      # PREFECT_PROJECT_NAME: buoy-barn-dev
+    volumes:
+      - ./app:/app
     env_file:
       - ./docker-data/test.env
     links:

--- a/docker-data/test.env
+++ b/docker-data/test.env
@@ -1,0 +1,8 @@
+POSTGRES_PASSWORD=nmMesPYd*ccRQ*-AvK3n
+POSTGRES_USER=buoy_barn
+POSTGRES_NAME=buoy_barn
+POSTGRES_HOST=db
+SECRET_KEY=cyuf.MCM6aqFPwxJsgJFw_C3HZTs.ujD6*3is.AWXboJ!sQg@@aFXeVw8ef88hk@!sjNUDPPE6R8AfkAAEhjmRQ-ueR8qaM-Leha
+CELERY_BROKER_URL=redis://cache:6379/1
+DJANGO_ENV=test
+REDIS_CACHE=redis://cache:6379/0


### PR DESCRIPTION
Reduce need to access secrets during testing to reduce problems with PRs from forks. See [1](https://github.community/t/dependabot-prs-and-workflow-secrets/163269/23) [2](https://github.community/t/dependabot-doesnt-see-github-actions-secrets/167104/25)