### PR TITLE
Fixes timeouts due to upstream erddap servers being down

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,9 @@ Changes:
 
 Fixes:
 
+- Adds a timeout to proxied requests. Closes #457
+  - Timeout can be set with the environment variable `PROXY_TIMEOUT_SECONDS` and defaults to 30 seconds.
+
 ## 0.4.0 - 08/12/2021
 
 Additions:

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
     build-essential=12.6
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install poetry==1.1.5 \
+    pip install poetry==1.1.11 \
     && groupadd uwsgi && useradd -g uwsgi uwsgi
 
 # Working directory

--- a/app/buoy_barn/settings.py
+++ b/app/buoy_barn/settings.py
@@ -122,6 +122,9 @@ CACHES = {
 # How many seconds should CORS proxied data from ERDDAP servers be cached
 PROXY_CACHE_SECONDS = int(os.environ.get("PROXY_CACHE_SECONDS", 60))
 
+# How many seconds should requests to a proxy
+PROXY_TIMEOUT_SECONDS = int(os.environ.get("PROXY_TIMEOUT_SECONDS", 30))
+
 WSGI_APPLICATION = "buoy_barn.wsgi.application"
 
 


### PR DESCRIPTION
- Adds a timeout to proxied requests. Closes #457
  - Timeout can be set with the environment variable `PROXY_TIMEOUT_SECONDS` and defaults to 30 seconds.

Closes #457