### PR TITLE
No duplicate tasks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ Changes:
 
 Fixes:
 
+- Avoids scheduling additional dataset or server refreshes if there is already a refresh task in the queue. This works by when the `/refresh/` view is triggered, it instead schedules a quick task that then checks if the refresh is scheduled (or active or reserved). If it is already scheduled it throws a warning, otherwise it schedules the task.
+
 ## 0.4.11 - 12/20/2022
 
 Fixes:

--- a/app/deployments/tests/test_api.py
+++ b/app/deployments/tests/test_api.py
@@ -249,7 +249,7 @@ class BuoyBarnPlatformAPITestCase(APITestCase):
         self.assertIn("base_url", response.data)
         self.assertIn("url", response.data)
 
-    @patch("deployments.tasks.refresh_server.delay")
+    @patch("deployments.tasks.single_refresh_server.delay")
     def test_server_refresh(self, refresh_server):
         response = self.client.get("/api/servers/1/refresh/", format="json")
 
@@ -279,7 +279,7 @@ class BuoyBarnPlatformAPITestCase(APITestCase):
         self.assertIn("name", response.data["server"])
 
     @my_vcr.use_cassette("dataset_detail.yaml")
-    @patch("deployments.tasks.refresh_dataset.delay")
+    @patch("deployments.tasks.single_refresh_dataset.delay")
     def test_dataset_refresh(self, refresh_dataset):
         response = self.client.get(
             "/api/datasets/NERACOOS-N01_sbe37_all/refresh/",


### PR DESCRIPTION
Avoids scheduling additional dataset or server refreshes if there is already a refresh task in the queue. This works by when the `/refresh/` view is triggered, it instead schedules a quick task that then checks if the refresh is scheduled (or active or reserved). If it is already scheduled it throws a warning, otherwise it schedules the task.