### PR TITLE
Add no-commit-to-branch pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-docstring-first
       - id: check-added-large-files
+      - id: no-commit-to-branch
 
   # Looks for docstrings
   # - repo: https://github.com/econchick/interrogate


### PR DESCRIPTION
Adds a hook to prevent mistaken commits to the main branch.

https://github.com/pre-commit/pre-commit-hooks#no-commit-to-branch