### PR TITLE
Fix N+1 queries again

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ Changes:
 
 Fixes:
 
+- Attempt to to fix N+1 query from `/api/platforms/` where Django wasn't pre-fetching the timeseries for the platforms, so they were being fetched on the fly as the serializer tried to assemble the output. Fixes [#793](https://github.com/gulfofmaine/buoy_barn/issues/793)
+
 ## 0.4.17 - 06/19/2023
 
 Fixes:

--- a/app/deployments/models.py
+++ b/app/deployments/models.py
@@ -5,9 +5,7 @@ from enum import Enum
 
 import requests
 from django.contrib.gis.db import models
-from django.urls import reverse
 from erddapy import ERDDAP
-from memoize import memoize
 
 logger = logging.getLogger(__name__)
 
@@ -54,36 +52,6 @@ class Platform(models.Model):
         if self.geom:
             return self.geom
         return None
-
-    @memoize(timeout=5 * 60)
-    def latest_erddap_values(self):
-        readings = []
-        for series in self.timeseries_set.filter(active=True).select_related(
-            "data_type",
-            "dataset",
-            "dataset__server",
-        ):  # .filter(end_time=None):
-            if not series.end_time:
-                readings.append(
-                    {
-                        "value": series.value,
-                        "time": series.value_time,
-                        "depth": series.depth,
-                        "data_type": series.data_type.json,
-                        "server": series.dataset.server.base_url,
-                        "variable": series.variable,
-                        "constraints": series.constraints,
-                        "dataset": series.dataset.name,
-                        "start_time": series.start_time,
-                        "cors_proxy_url": reverse(
-                            "server-proxy",
-                            kwargs={"server_id": series.dataset.server.id},
-                        )
-                        if series.dataset.server.proxy_cors
-                        else None,
-                    },
-                )
-        return readings
 
     def current_alerts(self):
         alerts = []


### PR DESCRIPTION
What I thought previously worked was just hidden by the cache. Here we get creative with the `Prefetch` function to explicitly filter the timeseries separate from the platforms and move the readings aggregation to the serializer from the model to help control fetching.

Closes #793