### PR TITLE
0.4.18

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,19 @@ Changes:
 
 Fixes:
 
+## 0.4.18 - 06/19/2023
+
+Fixes:
+
 - Attempt to to fix N+1 query from `/api/platforms/` where Django wasn't pre-fetching the timeseries for the platforms, so they were being fetched on the fly as the serializer tried to assemble the output. Fixes [#793](https://github.com/gulfofmaine/buoy_barn/issues/793)
+
+Dependency updates:
+
+- Pre-commit
+  - Pyupgrade from 3.6.0 to 3.7.0
+  - Gitleaks from 8.16.4 to 8.17.0
+  - Django-upgrade from 1.13.0 to 1.14.0
+- Redis from 5.0.3 to 5.0.14
 
 ## 0.4.17 - 06/19/2023
 

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "buoy_barn"
-version = "0.4.17"
+version = "0.4.18"
 description = "NERACOOS lightweight API sitting in front of ERDDAP"
 authors = ["Alex Kerney <akerney@gmri.org>"]
 


### PR DESCRIPTION
Fixes:

- Attempt to to fix N+1 query from `/api/platforms/` where Django wasn't pre-fetching the timeseries for the platforms, so they were being fetched on the fly as the serializer tried to assemble the output. Fixes [#793](https://github.com/gulfofmaine/buoy_barn/issues/793)

Dependency updates:

- Pre-commit
  - Pyupgrade from 3.6.0 to 3.7.0
  - Gitleaks from 8.16.4 to 8.17.0
  - Django-upgrade from 1.13.0 to 1.14.0
- Redis from 5.0.3 to 5.0.14