### PR TITLE
Admin and API tweaks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@ Additions:
 
 Changes:
 
+- API views to see which platforms have active timeseries for an ERDDAP server or dataset.
+- Admin filters to select platforms by ERDDAP server, dataset, active timeseries, or standard name (data type).
+- Customized the admin display for timeseries to make it more compact and collapse less useful info.
+
 Fixes:
 
 ## 0.4.18 - 06/19/2023

--- a/app/deployments/models.py
+++ b/app/deployments/models.py
@@ -340,6 +340,9 @@ class TimeSeries(models.Model):
 
         return server.get_download_url()
 
+    class Meta:
+        ordering = ["data_type"]
+
 
 class Alert(models.Model):
     platform = models.ForeignKey(

--- a/app/deployments/serializers.py
+++ b/app/deployments/serializers.py
@@ -99,5 +99,4 @@ class ErddapDatasetSerializer(serializers.ModelSerializer):
         depth = 2
 
     def get_slug(self, obj):
-        print(self, obj)
         return f"{obj.server.name}-{obj.name}"


### PR DESCRIPTION
- API views to see which platforms have active timeseries for an ERDDAP server or dataset.
- Admin filters to select platforms by ERDDAP server, dataset, active timeseries, or standard name (data type).
- Customized the admin display for timeseries to make it more compact and collapse less useful info.

<img width="1225" alt="image" src="https://github.com/gulfofmaine/buoy_barn/assets/1296209/cf823b90-382e-470a-a5f2-48c1ca228113">


<img width="1206" alt="image" src="https://github.com/gulfofmaine/buoy_barn/assets/1296209/ab7e0150-7166-4612-88c1-d749cf5e94ea">
