### PR TITLE
Recover from invalid timeseries data type errors

### DIFF
--- a/app/buoy_barn/settings.py
+++ b/app/buoy_barn/settings.py
@@ -58,25 +58,27 @@ def trace_filter(trace: dict) -> float:
     except KeyError:
         pass
 
+    # Send all traces to spotlight during during development
+    if os.environ.get("DJANGO_ENV", "").lower() == "dev":
+        return 1
+
     return SENTRY_TRACES_SAMPLE_RATE
 
 
 if os.environ.get("DJANGO_ENV", "").lower() != "test":
-    try:
-        pyproject = toml.load("pyproject.toml")
-        version = pyproject["tool"]["poetry"]["version"]
-        sentry_sdk.init(
-            dsn=os.environ["SENTRY_DSN"],
-            integrations=[CeleryIntegration(), DjangoIntegration(), RedisIntegration()],
-            environment="dev" if DEBUG else "prod",
-            release=f"v{version}",
-            traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
-            traces_sampler=trace_filter,
-            before_send=before_send,
-        )
-        logger.info("Sentry initialized")
-    except KeyError:
-        logger.warning("SENTRY_DSN missing. Sentry is not initialized")
+    pyproject = toml.load("pyproject.toml")
+    version = pyproject["tool"]["poetry"]["version"]
+    sentry_sdk.init(
+        dsn=os.environ.get("SENTRY_DSN"),
+        integrations=[CeleryIntegration(), DjangoIntegration(), RedisIntegration()],
+        environment="dev" if DEBUG else "prod",
+        release=f"v{version}",
+        traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
+        spotlight=(os.environ.get("DJANGO_ENV") == "dev")
+        and "http://spotlight:8969/stream",
+        traces_sampler=trace_filter,
+        before_send=before_send,
+    )
 else:
     logger.info("Sentry disabled when DJANGO_ENV=test")
 

--- a/app/deployments/tasks/refresh.py
+++ b/app/deployments/tasks/refresh.py
@@ -63,16 +63,19 @@ def update_values_for_timeseries(timeseries):
         for series in timeseries:
             filtered_df = filter_dataframe(df, series.variable)
 
+            extra_context = {
+                "timeseries": timeseries,
+                "constraints": timeseries[0].constraints,
+            }
+
             try:
                 row = filtered_df.iloc[-1]
+                extra_context["row"] = row
             except IndexError:
                 logger.error(
                     f"Unable to find position in dataframe for {series.platform.name} - "
                     f"{series.variable}",
-                    extra={
-                        "timeseries": timeseries,
-                        "constraints": timeseries[0].constraints,
-                    },
+                    extra=extra_context,
                     exc_info=True,
                 )
                 continue
@@ -83,21 +86,31 @@ def update_values_for_timeseries(timeseries):
                 ]
                 value = row[variable_name]
 
+                extra_context["series"] = series
+                extra_context["variable"] = series.variable
+                extra_context["value"] = value
+
                 if isinstance(value, Timedelta):
                     logger.info("Converting from Timedelta to seconds")
                     value = value.seconds
 
                 series.value = value
+
                 time = row["time (UTC)"]
+                extra_context["time"] = time
+
                 series.value_time = parse_time_string(time)[0]
                 series.save()
             except TypeError as error:
                 logger.error(
                     f"Could not save {series.variable} from {row}: {error}",
-                    extra={
-                        "timeseries": timeseries,
-                        "constraints": timeseries[0].constraints,
-                    },
+                    extra=extra_context,
+                    exc_info=True,
+                )
+            except ValueError as error:
+                logger.error(
+                    f"Could not save {series.variable} from {row}: {error}",
+                    extra=extra_context,
                     exc_info=True,
                 )
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -73,3 +73,8 @@ services:
       - cache
     ports:
       - "5555:5555"
+
+  spotlight:
+    image: ghcr.io/getsentry/spotlight:latest
+    ports:
+      - "8969:8969/tcp"


### PR DESCRIPTION
This doesn't solve them, but instead of failing to load the remaining timeseries, it continues and logs the error with some more detail.

Additionally adds Sentry Spotlight to help chase down said errors in development.

Closes #1015