### PR TITLE
Make end_time of timeseries more clear

### DIFF
--- a/app/deployments/admin.py
+++ b/app/deployments/admin.py
@@ -59,14 +59,23 @@ class TimeSeriesInline(admin.StackedInline):
             None,
             {
                 "fields": [
-                    (
-                        "dataset",
-                        "variable",
-                    ),
-                    ("data_type", "depth"),
-                    ("value_time", "constraints"),
-                    ("value", "active"),
-                    ("test_timeseries",),
+                    ("dataset", "variable"),
+                    ("data_type", "active"),
+                    ("value_time", "end_time"),
+                    ("value", "test_timeseries"),
+                ],
+            },
+        ),
+        (
+            "Advanced",
+            {
+                "classes": ["collapse"],
+                "fields": [
+                    ("constraints", "depth"),
+                    ("buffer_type",),
+                    ("datum_mhhw_meters", "datum_mhw_meters"),
+                    ("datum_mtl_meters", "datum_msl_meters"),
+                    ("datum_mlw_meters", "datum_mllw_meters"),
                 ],
             },
         ),


### PR DESCRIPTION
Brings end_time back into view for timeseries, and brings back the collapsed Advanced view which now contains constraints, depth, buffer type, and datums. 

<img width="1101" alt="image" src="https://github.com/user-attachments/assets/19bada3c-ead1-418a-821f-7cd051867443">

<img width="1078" alt="image" src="https://github.com/user-attachments/assets/2b2bf721-1f8b-4402-a1b2-a6bc778cb878">


In theorythis will help make it easier to understand what might be happening by highlighting the current control state of a timeseries, and it's current data to make it more operationally focused, and allow more config focuesed fields to be expanded as needed.