### PR TITLE
Enable GZip middleware

### DIFF
--- a/app/buoy_barn/settings.py
+++ b/app/buoy_barn/settings.py
@@ -253,6 +253,8 @@ if DEBUG:
         return True
 
     DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": show_toolbar}
+else:
+    MIDDLEWARE = ["django.middleware.gzip.GZipMiddleware"] + MIDDLEWARE
 
 
 SLACK_API_TOKEN = os.environ.get("SLACK_API_TOKEN")


### PR DESCRIPTION
Enable GZip middleware in production to help further speed up Mariner's and other interactions with Buoy Barn 

xref https://github.com/gulfofmaine/Neracoos-1-Buoy-App/issues/3083