### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         exclude: .*\/tests\/.*
 
   - repo: https://github.com/zricethezav/gitleaks/
-    rev: v8.21.1
+    rev: v8.21.2
     hooks:
       - id: gitleaks
 
@@ -51,13 +51,13 @@ repos:
         args: [--target-version, "5.0"]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 2.2.4
+    rev: v2.4.3
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.7.0
+    rev: v0.7.1
     hooks:
     # Run the linter.
     - id: ruff

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -8,6 +8,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
   "celery~=5.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Hooks updated:
- Gitleaks from 8.21.1 to 8.21.2
- Pyproject fmt from 2.2.4 to 2.4.3
- Ruff from 0.7.0 to 0.7.1