### PR TITLE
Small N+1 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ user:
 	docker compose exec web manage.py createsuperuser
 
 shell:
-	docker compose exec web manage.py shell
+	docker compose exec web uv run manage.py shell
 
 test:
 	docker compose -f docker-compose.test.yaml run --rm -e DJANGO_ENV=test web-test uv run pytest --cov=. --cov-config=tox.ini --cov-report=xml:./coverage.xml

--- a/app/deployments/models.py
+++ b/app/deployments/models.py
@@ -283,7 +283,11 @@ class ErddapDataset(models.Model):
     def group_timeseries_by_constraint(self):
         groups = defaultdict(list)
 
-        for ts in self.timeseries_set.filter(end_time=None, active=True):
+        for ts in (
+            self.timeseries_set.filter(end_time=None, active=True)
+            .select_related("platform")
+            .prefetch_related("data_type")
+        ):
             try:
                 groups[tuple((ts.constraints or {}).items())].append(ts)
             except AttributeError as e:


### PR DESCRIPTION
Fix a N+1 query in refresh_dataset, but it's out of the request loop, so not as critical for user performance.

Closes #1244