### PR TITLE
Admin updates and periodic refresh 

### DIFF
--- a/app/deployments/utils/erddap_datasets.py
+++ b/app/deployments/utils/erddap_datasets.py
@@ -42,6 +42,7 @@ def setup_variables(  # noqa: PLR0913
         constraints["time<="] = datetime.now(UTC) + timedelta(days=7)
     else:
         constraints["time>="] = datetime.now(UTC) - timedelta(hours=24)
+        constraints["time<="] = datetime.now(UTC)
 
     server.constraints = constraints
 


### PR DESCRIPTION
This adds a healthcheck to the periodic refresh, so that we know if it isn't firing as expected (which caused a lot of data to go out of date when it's memory needs to launch increased).

This also includes constraining max time requested when a timeseries isn't a forecast, so we don't try to pull from too far into the future.