### PR TITLE
Match the default time range for forecast and prediction window

### DIFF
--- a/app/deployments/utils/erddap_datasets.py
+++ b/app/deployments/utils/erddap_datasets.py
@@ -48,7 +48,7 @@ def setup_variables(  # noqa: PLR0913
         constraints["time>="] = time
     elif forecast:
         constraints["time>="] = datetime.now(UTC)
-        constraints["time<="] = datetime.now(UTC) + timedelta(days=7)
+        constraints["time<="] = datetime.now(UTC) + timedelta(days=3)
     else:
         constraints["time>="] = datetime.now(UTC) - timedelta(hours=24)
         constraints["time<="] = datetime.now(UTC)


### PR DESCRIPTION
Currently the water level viewer shows a 3 day window before and after, so lets limit the forecast and predictions to 3 days as well, so we don't display an alert that people don't see