### PR TITLE
Release 0.8.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,38 @@ Changes:
 
 Fixes:
 
+## 0.8.0 - 2025-04-03
+
+Changes:
+
+* Let users manually configure which services (Mariners/dev/Climatology) platforms are visible to by @abkfenris in https://github.com/gulfofmaine/buoy_barn/pull/1345
+* A new platform type (Virtual) for platforms. This gives a designated type for datasets where there may not be a single physical location, but we are aggregating as if there was one (eMOLT) by @abkfenris in https://github.com/gulfofmaine/buoy_barn/pull/1354
+
+Dependency updates:
+
+* Bump getsentry/action-release from 3.1.0 to 3.1.1 by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1342
+* Bump django-debug-toolbar from 4.4.6 to 5.1.0 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1341
+* Bump sentry-sdk from 2.19.2 to 2.23.1 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1336
+* Bump whitenoise from 6.8.2 to 6.9.0 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1331
+* Update geojson requirement from ~=3.1.0 to ~=3.2.0 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1322
+* Bump slack-sdk from 3.33.5 to 3.35.0 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1337
+* Update pystac requirement from ~=1.11.0 to ~=1.12.2 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1319
+* Update vcrpy requirement from ~=6.0 to ~=7.0 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1323
+* Bump xarray from 2024.11.0 to 2025.3.0 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1339
+* Bump scipy from 1.14.1 to 1.15.2 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1333
+* Bump django-cors-headers from 4.6.0 to 4.7.0 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1343
+* Bump sentry-sdk from 2.24.0 to 2.24.1 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1344
+* Remove prospector by @abkfenris in https://github.com/gulfofmaine/buoy_barn/pull/1346
+* Bump xarray from 2025.3.0 to 2025.3.1 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1349
+* Update pre-commit hook adamchainz/django-upgrade to v1.24.0 by @renovate in https://github.com/gulfofmaine/buoy_barn/pull/1352
+* Bump sentry-sdk from 2.24.1 to 2.25.0 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1353
+* Update docker/dockerfile Docker tag to v1.14 by @renovate in https://github.com/gulfofmaine/buoy_barn/pull/1348
+* Bump Django to 5.1.8 by @abkfenris in https://github.com/gulfofmaine/buoy_barn/pull/1355
+* Bump sentry-sdk from 2.25.0 to 2.25.1 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1356
+
+
+**Full Changelog**: https://github.com/gulfofmaine/buoy_barn/compare/v0.7.6...v0.8.0
+
 ## 0.7.6 - 2025-03-19
 
 ## What's Changed

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "buoy-barn"
-version = "0.7.6"
+version = "0.8.0"
 description = "NERACOOS lightweight API sitting in front of ERDDAP"
 authors = [ { name = "Alex Kerney", email = "<akerney@gmri.org>" } ]
 requires-python = ">=3.11"

--- a/app/uv.lock
+++ b/app/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version < '3.12' and platform_python_implementation == 'PyPy'",
@@ -75,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "buoy-barn"
-version = "0.7.6"
+version = "0.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "celery" },
@@ -116,31 +115,31 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "celery", specifier = "==5.4.0" },
-    { name = "django", specifier = "==5.1.8" },
-    { name = "django-cors-headers", specifier = "==4.7.0" },
-    { name = "django-debug-toolbar", specifier = "==5.1.0" },
-    { name = "django-health-check", specifier = "==3.18.3" },
-    { name = "django-memoize", specifier = "==2.3.1" },
-    { name = "django-redis", specifier = "==5.4.0" },
-    { name = "djangorestframework", specifier = "==3.15.2" },
-    { name = "djangorestframework-gis", specifier = "==1.1" },
-    { name = "erddapy", specifier = "==2.2.3" },
-    { name = "flower", specifier = "==2.0.1" },
-    { name = "freezegun", specifier = "==1.5.1" },
-    { name = "geojson", specifier = "==3.2.0" },
-    { name = "netcdf4", specifier = "==1.7.2" },
-    { name = "pandas", specifier = "==2.2.3" },
-    { name = "psycopg2-binary", specifier = "==2.9.10" },
-    { name = "pystac", specifier = "==1.12.2" },
-    { name = "requests", specifier = "==2.32.3" },
-    { name = "scipy", specifier = "==1.15.2" },
+    { name = "celery", specifier = "~=5.4" },
+    { name = "django", specifier = "<5.2" },
+    { name = "django-cors-headers", specifier = "~=4.4" },
+    { name = "django-debug-toolbar", specifier = "~=5.1" },
+    { name = "django-health-check", specifier = "~=3.18.3" },
+    { name = "django-memoize", specifier = "~=2.3.1" },
+    { name = "django-redis", specifier = "~=5.4" },
+    { name = "djangorestframework", specifier = "~=3.15" },
+    { name = "djangorestframework-gis", specifier = "~=1.0" },
+    { name = "erddapy", specifier = ">1.2.1" },
+    { name = "flower", specifier = "~=2.0.1" },
+    { name = "freezegun", specifier = "~=1.5.1" },
+    { name = "geojson", specifier = "~=3.2.0" },
+    { name = "netcdf4", specifier = "~=1.7.1" },
+    { name = "pandas", specifier = ">1.5.3" },
+    { name = "psycopg2-binary", specifier = "~=2.9.9" },
+    { name = "pystac", specifier = "~=1.12.2" },
+    { name = "requests", specifier = ">=2.32.3" },
+    { name = "scipy", specifier = ">=1.14.1" },
     { name = "sentry-sdk", specifier = "~=2.25.0" },
-    { name = "slack-sdk", specifier = "==3.35.0" },
-    { name = "uwsgi", specifier = "==2.0.28" },
-    { name = "vcrpy", specifier = "==7.0.0" },
-    { name = "whitenoise", specifier = "==6.9.0" },
-    { name = "xarray", specifier = "==2025.3.1" },
+    { name = "slack-sdk", specifier = "~=3.35.0" },
+    { name = "uwsgi", specifier = "~=2.0.26" },
+    { name = "vcrpy", specifier = "~=7.0" },
+    { name = "whitenoise", specifier = "~=6.7" },
+    { name = "xarray", specifier = "~=2025.3.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Changes:
* Let users manually configure which services (Mariners/dev/Climatology) platforms are visible to by @abkfenris in https://github.com/gulfofmaine/buoy_barn/pull/1345
* A new platform type (Virtual) for platforms. This gives a designated type for datasets where there may not be a single physical location, but we are aggregating as if there was one (eMOLT) by @abkfenris in https://github.com/gulfofmaine/buoy_barn/pull/1354

Dependency updates:

* Bump getsentry/action-release from 3.1.0 to 3.1.1 by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1342
* Bump django-debug-toolbar from 4.4.6 to 5.1.0 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1341
* Bump sentry-sdk from 2.19.2 to 2.23.1 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1336
* Bump whitenoise from 6.8.2 to 6.9.0 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1331
* Update geojson requirement from ~=3.1.0 to ~=3.2.0 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1322
* Bump slack-sdk from 3.33.5 to 3.35.0 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1337
* Update pystac requirement from ~=1.11.0 to ~=1.12.2 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1319
* Update vcrpy requirement from ~=6.0 to ~=7.0 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1323
* Bump xarray from 2024.11.0 to 2025.3.0 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1339
* Bump scipy from 1.14.1 to 1.15.2 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1333
* Bump django-cors-headers from 4.6.0 to 4.7.0 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1343
* Bump sentry-sdk from 2.24.0 to 2.24.1 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1344
* Remove prospector by @abkfenris in https://github.com/gulfofmaine/buoy_barn/pull/1346
* Bump xarray from 2025.3.0 to 2025.3.1 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1349
* Update pre-commit hook adamchainz/django-upgrade to v1.24.0 by @renovate in https://github.com/gulfofmaine/buoy_barn/pull/1352
* Bump sentry-sdk from 2.24.1 to 2.25.0 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1353
* Update docker/dockerfile Docker tag to v1.14 by @renovate in https://github.com/gulfofmaine/buoy_barn/pull/1348
* Bump Django to 5.1.8 by @abkfenris in https://github.com/gulfofmaine/buoy_barn/pull/1355
* Bump sentry-sdk from 2.25.0 to 2.25.1 in /app by @dependabot in https://github.com/gulfofmaine/buoy_barn/pull/1356


**Full Changelog**: https://github.com/gulfofmaine/buoy_barn/compare/v0.7.6...v0.8.0