### PR TITLE
UV Pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,14 @@ repos:
       - id: check-added-large-files
       - id: no-commit-to-branch
 
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.6.12
+    hooks:
+      # Update the uv lockfile
+      - id: uv-lock
+        files: app/pyproject.toml
+        args: [--project, app]
+
   # - repo: https://github.com/codespell-project/codespell
   #   rev: v2.1.0
   #   hooks:


### PR DESCRIPTION
Set up a pre-commit hook to make sure the UV lock file is synced (because I often forget to do so when bumping the version).