### PR TITLE
Dependabot - remove reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
     interval: daily
     time: '10:00'
   open-pull-requests-limit: 10
-  reviewers:
-  - abkfenris
 - package-ecosystem: docker
   directory: "/app"
   schedule:


### PR DESCRIPTION
I guess the field is being removed in place of CODEOWNERS