### PR TITLE
Fixes 500 & TypeError when a new dataset hasn't been refreshed

### DIFF
--- a/app/deployments/admin.py
+++ b/app/deployments/admin.py
@@ -582,18 +582,18 @@ class ErddapDatasetAdmin(DjangoObjectActions, admin.ModelAdmin):
 
     @admin.display(description="Refresh attempted")
     def refresh_status(self, obj: ErddapDataset):
-        now = timezone.now()
-        hour_ago = now - timedelta(hours=24)
-        day_ago = now - timedelta(days=1)
-
-        last_refreshed = f"Last refreshed at: {obj.refresh_attempted:%Y-%m-%d %H:%M}"
-
         if obj.refresh_attempted is None:
             return format_html(
                 "<span style='color: {};'>{}</span>",
                 "gray",
                 "Never refreshed",
             )
+
+        now = timezone.now()
+        hour_ago = now - timedelta(hours=1)
+        day_ago = now - timedelta(days=1)
+
+        last_refreshed = f"Last refreshed at: {obj.refresh_attempted:%Y-%m-%d %H:%M}"
         if obj.refresh_attempted < day_ago:
             return format_html(
                 "<span style='color: {};' title='{}'>{}</span>",

--- a/app/deployments/tests/test_admin.py
+++ b/app/deployments/tests/test_admin.py
@@ -1,9 +1,11 @@
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
 from django.contrib.admin.sites import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test import RequestFactory, TestCase
+from django.utils import timezone
 
 from deployments.admin import ErddapDatasetAdmin, ErddapServerAdmin, PlatformAdmin
 from deployments.models import (
@@ -115,6 +117,30 @@ class ErddapDatasetAdminObjectActionsTestCase(TestCase):
         self.admin.refresh_erddap_dataset(request, self.dataset)
 
         mock_delay.assert_called_once_with(self.dataset.id, healthcheck=False)
+
+    def test_refresh_status_never_refreshed(self):
+        """Regression: refresh_attempted=None must not raise TypeError."""
+        self.dataset.refresh_attempted = None
+        result = self.admin.refresh_status(self.dataset)
+        self.assertIn("Never refreshed", result)
+
+    def test_refresh_status_recent(self):
+        self.dataset.refresh_attempted = timezone.now() - timedelta(minutes=30)
+        result = self.admin.refresh_status(self.dataset)
+        self.assertIn("green", result)
+        self.assertIn("Less than 1 hour ago", result)
+
+    def test_refresh_status_more_than_one_hour(self):
+        self.dataset.refresh_attempted = timezone.now() - timedelta(hours=2)
+        result = self.admin.refresh_status(self.dataset)
+        self.assertIn("yellow", result)
+        self.assertIn("More than 1 hour ago", result)
+
+    def test_refresh_status_more_than_one_day(self):
+        self.dataset.refresh_attempted = timezone.now() - timedelta(days=2)
+        result = self.admin.refresh_status(self.dataset)
+        self.assertIn("red", result)
+        self.assertIn("More than 24 hours ago", result)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes viewing the dataset admin when a new dataset (or one without timeseries to refresh) doesn’t have a value.

Additionally fixes some logic that was causing refreshes between 1 and 24 hours not to be shown.

Closes https://github.com/gulfofmaine/buoy_barn/issues/1720