### PR TITLE
Add dev container configuration for local dev, Codespaces, and Claude Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+{
+  "name": "Buoy Barn",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/buoy_barn",
+  "remoteUser": "vscode",
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
+  },
+  "forwardPorts": [8090, 5432, 5555],
+  "portsAttributes": {
+    "8090": {
+      "label": "Django (web)",
+      "onAutoForward": "notify"
+    },
+    "5432": {
+      "label": "PostGIS"
+    },
+    "5555": {
+      "label": "Celery Flower"
+    }
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "charliermarsh.ruff",
+        "batisteo.vscode-django",
+        "tamasfe.even-better-toml",
+        "ms-azuretools.vscode-docker"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/workspaces/buoy_barn/app/.venv/bin/python",
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.formatOnSave": true
+        }
+      }
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,57 @@
+# Dev Container stack. Reuses the shared service definitions from
+# ../docker-compose.base.yaml via `extends:` so images/build stay in one place.
+# Unlike the main stack this file supplies its own inline dev environment (no
+# ./docker-data/secret.env needed) and starts only db, cache, and the app shell.
+services:
+  db:
+    extends:
+      file: ../docker-compose.base.yaml
+      service: db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: buoy_barn
+      POSTGRES_PASSWORD: buoy_barn
+      POSTGRES_DB: buoy_barn
+    # Directory bind mount (not a named volume) so the database persists on the
+    # host across rebuilds. Separate dir from the main stack's docker-data/postgres
+    # so these fixed dev credentials can't clash with a real secret.env.
+    volumes:
+      - ../docker-data/devcontainer-db:/var/lib/postgresql/data
+
+  cache:
+    extends:
+      file: ../docker-compose.base.yaml
+      service: cache
+    restart: unless-stopped
+
+  app:
+    extends:
+      file: ../docker-compose.base.yaml
+      service: app
+    build:
+      target: devcontainer
+    image: buoy_barn_devcontainer
+    command: sleep infinity
+    user: vscode
+    volumes:
+      - ..:/workspaces/buoy_barn:cached
+      # Persist Claude Code auth/settings/history across container rebuilds.
+      - claude-code-config:/home/vscode/.claude
+    environment:
+      DJANGO_ENV: dev
+      SECRET_KEY: dev-only-insecure-secret-key-change-me
+      POSTGRES_HOST: db
+      POSTGRES_NAME: buoy_barn
+      POSTGRES_USER: buoy_barn
+      POSTGRES_PASSWORD: buoy_barn
+      POSTGRES_PORT: "5432"
+      REDIS_CACHE: redis://cache:6379/0
+      CELERY_BROKER_URL: redis://cache:6379/1
+      SENTRY_TRACES_SAMPLE_RATE: "0"
+      DJANGO_MANAGEPY_MIGRATE: "off"
+    depends_on:
+      - db
+      - cache
+
+volumes:
+  claude-code-config:

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# First-run bootstrap for the dev container. Idempotent: safe to re-run, and it
+# skips seeding when the (persisted) database already has data.
+set -euo pipefail
+
+# Work from the Django project directory regardless of where we're invoked from.
+cd "$(dirname "$0")/../app"
+
+echo "==> Installing Python dependencies (uv sync)"
+uv sync
+
+echo "==> Applying database migrations"
+uv run manage.py migrate --noinput
+
+# Seed fixtures only when the database has no platforms yet, so rebuilds against
+# the persisted data directory don't re-import on every container start.
+platform_count="$(uv run manage.py shell -c \
+  'from deployments.models import Platform; print(Platform.objects.count())' \
+  2>/dev/null | tail -n 1 | tr -d '[:space:]')"
+
+if [ "${platform_count:-0}" = "0" ]; then
+  echo "==> Seeding database from fixtures"
+  uv run manage.py loaddata \
+    deployments/fixtures/platforms.yaml \
+    deployments/fixtures/Alerts.yaml \
+    deployments/fixtures/datatypes.yaml \
+    deployments/fixtures/deployments.yaml \
+    deployments/fixtures/erddapservers.yaml \
+    deployments/fixtures/ErddapDataset.yaml \
+    deployments/fixtures/programs.yaml \
+    deployments/fixtures/platformattribution.yaml \
+    deployments/fixtures/TimeSeries.yaml
+else
+  echo "==> Database already has ${platform_count} platform(s); skipping fixtures"
+fi
+
+# Create a default admin user only if one does not already exist.
+admin_exists="$(uv run manage.py shell -c \
+  'from django.contrib.auth import get_user_model; print(get_user_model().objects.filter(username="admin").exists())' \
+  2>/dev/null | tail -n 1 | tr -d '[:space:]')"
+
+if [ "${admin_exists}" = "True" ]; then
+  echo "==> Superuser 'admin' already exists; skipping"
+else
+  echo "==> Creating default superuser (admin / admin)"
+  DJANGO_SUPERUSER_PASSWORD="admin" uv run manage.py createsuperuser \
+    --noinput --username admin --email admin@example.com
+fi
+
+cat <<'EOF'
+
+Dev container ready.
+  Start the server:  cd app && uv run manage.py runserver 0:8090
+  Admin:  http://localhost:8090/admin/   (login: admin / admin)
+  API:    http://localhost:8090/api/
+EOF

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 docker-data/postgres
+docker-data/devcontainer-db
 secret.env
 .DS_Store
 

--- a/Readme.md
+++ b/Readme.md
@@ -105,6 +105,41 @@ Tests coverage can be run with `make coverage`.
 After the tests are run, and the report displayed in the command line, it will also generate an html report.
 This report can be viewed by opening `app/htmlcov/index.html` which will also attempt to automatically open in the default browser.
 
+## Dev Container / GitHub Codespaces
+
+For a one-click, batteries-included environment there is a
+[dev container](https://containers.dev/) under `.devcontainer/`. It works with
+VS Code (Dev Containers extension), GitHub Codespaces, and other editors that
+support the spec, and comes with the GDAL/GeoDjango toolchain, PostGIS, Redis,
+`uv`, and [Claude Code](https://code.claude.com/docs/en/devcontainer)
+preinstalled.
+
+- **VS Code:** open the repo and run **Dev Containers: Reopen in Container**.
+- **Codespaces:** *Code → Codespaces → Create codespace* on GitHub.
+
+On first creation `.devcontainer/post-create.sh` runs `uv sync`, applies
+migrations, loads the `deployments` fixtures, and creates a default superuser
+(`admin` / `admin`). It is idempotent — if the database already has data (the
+PostGIS data is persisted to the `docker-data/devcontainer-db/` directory) the
+fixture load and superuser creation are skipped.
+
+Once the container is ready, start the server from a terminal inside it:
+
+```bash
+cd app
+uv run manage.py runserver 0:8090
+```
+
+The admin is then at [localhost:8090/admin/](http://localhost:8090/admin/)
+(log in with `admin` / `admin`) and the API at
+[localhost:8090/api/](http://localhost:8090/api/). Redis is available at
+`cache:6379`, so a Celery worker can be started manually with
+`cd app && uv run celery -A buoy_barn worker -l info` if needed.
+
+The dev container reuses the same images and build as the main stack via the
+shared `docker-compose.base.yaml`; it does not need `docker-data/secret.env`
+(its development settings are supplied inline in `.devcontainer/docker-compose.yml`).
+
 ## Initial Configuration for Development
 
 ### Settings

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile:1.23
 # Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim@sha256:b3b7ad909281e78785cbc676c8c8b45816c31638b36dc0cbd9e51725f2f0399c
+FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim@sha256:b3b7ad909281e78785cbc676c8c8b45816c31638b36dc0cbd9e51725f2f0399c AS base
 
 # Output logging faster
 ENV PYTHONUNBUFFERED 1
@@ -18,6 +18,30 @@ RUN --mount=type=cache,target=/var/cache/apt \
     libproj-dev=9.6.0-1 \
     gdal-bin=3.10.3+dfsg-1 \
     build-essential=12.12
+
+# Development container stage: adds a non-root user and interactive tooling.
+# The Dev Containers spec / Claude Code feature require a non-root remoteUser,
+# which also lets Codespaces remap the user's UID onto the bind-mounted workspace.
+# No ENTRYPOINT/CMD - the devcontainer compose runs `sleep infinity`.
+FROM base AS devcontainer
+
+ARG USERNAME=vscode
+
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    sudo \
+    ca-certificates \
+    && groupadd --gid 1000 ${USERNAME} \
+    && useradd --uid 1000 --gid 1000 --create-home --shell /bin/bash ${USERNAME} \
+    && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME} \
+    && chmod 0440 /etc/sudoers.d/${USERNAME}
+
+WORKDIR /workspaces
+
+# Production stage. Kept last so the default build target (used by
+# docker-compose.test.yaml and `make build`) resolves to the production image.
+FROM base AS production
 
 RUN groupadd granian && useradd -g granian granian
 

--- a/docker-compose.base.yaml
+++ b/docker-compose.base.yaml
@@ -1,0 +1,23 @@
+# Shared service definitions extended by both docker-compose.yaml (the main
+# stack) and .devcontainer/docker-compose.yml via the compose `extends:` keyword.
+# Keep this file free of env_file / restart / command / per-environment volumes -
+# those belong in the consumers so each environment can differ.
+services:
+  db:
+    image: postgis/postgis:15-3.3@sha256:a2fc46b52819d25add4ed93d3da83e106e17ea3ace6883cce3791631c9820bb2
+    environment:
+      PGDATA: /var/lib/postgresql/data/PGDATA
+    ports:
+      - "5432:5432"
+
+  cache:
+    image: redis:7.4.8-alpine@sha256:7aec734b2bb298a1d769fd8729f13b8514a41bf90fcdd1f38ec52267fbaa8ee6
+
+  # Shared Django build, reused by web / mqtt / celery-* and the devcontainer.
+  # `target: production` keeps the main stack on the production image; the
+  # devcontainer overrides the target to `devcontainer`.
+  app:
+    build:
+      context: ./app
+      target: production
+    image: gmri/neracoos-buoy-barn

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,23 +1,24 @@
 services:
   db:
-    image: postgis/postgis:15-3.3@sha256:a2fc46b52819d25add4ed93d3da83e106e17ea3ace6883cce3791631c9820bb2
+    extends:
+      file: docker-compose.base.yaml
+      service: db
     restart: always
     env_file:
       - ./docker-data/secret.env
-    environment:
-      PGDATA: /var/lib/postgresql/data/PGDATA
     volumes:
       - ./docker-data/postgres:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
 
   cache:
-    image: redis:7.4.8-alpine@sha256:7aec734b2bb298a1d769fd8729f13b8514a41bf90fcdd1f38ec52267fbaa8ee6
+    extends:
+      file: docker-compose.base.yaml
+      service: cache
     restart: always
 
   web:
-    build: ./app
-    image: gmri/neracoos-buoy-barn
+    extends:
+      file: docker-compose.base.yaml
+      service: app
     command: uv run manage.py runserver 0:8090
     # command: "uv run granian --interface asgi --host 0.0.0.0 --port 8090 --workers 4 buoy_barn.asgi:application"
     restart: always
@@ -46,8 +47,9 @@ services:
       - cache
 
   mqtt:
-    build: ./app
-    image: gmri/neracoos-buoy-barn
+    extends:
+      file: docker-compose.base.yaml
+      service: app
     command: uv run manage.py erddap_mqtt NERACOOS_SEA_EAGLE
     volumes:
       - ./app:/app:cached
@@ -65,8 +67,9 @@ services:
       - erddap_mqtt_network
 
   celery-worker:
-    build: ./app
-    image: gmri/neracoos-buoy-barn
+    extends:
+      file: docker-compose.base.yaml
+      service: app
     command: celery -A buoy_barn worker -l info
     restart: always
     env_file:
@@ -76,8 +79,9 @@ services:
       - cache
 
   celery-beat:
-    build: ./app
-    image: gmri/neracoos-buoy-barn
+    extends:
+      file: docker-compose.base.yaml
+      service: app
     command: celery -A buoy_barn beat -l info
     restart: always
     env_file:
@@ -87,8 +91,9 @@ services:
       - cache
 
   celery-flower:
-    build: ./app
-    image: gmri/neracoos-buoy-barn
+    extends:
+      file: docker-compose.base.yaml
+      service: app
     command: celery -A buoy_barn flower -l info
     restart: always
     env_file:


### PR DESCRIPTION
Introduce a Dev Containers spec setup under .devcontainer/ so the project can
be opened one-click in VS Code, GitHub Codespaces, or any spec-compatible
editor, with Claude Code preinstalled.

To keep things DRY, service definitions are shared through a new
docker-compose.base.yaml that both the main stack and the dev container extend
via the compose `extends:` keyword, and the dev container image is a new
`devcontainer` stage in the existing app/Dockerfile rather than a duplicate
Dockerfile.

- app/Dockerfile: split into base / devcontainer / production stages; the
  production stage stays last so the default build target (test compose and
  `make build`) is unchanged. The devcontainer stage adds a non-root `vscode`
  user and interactive tooling.
- docker-compose.base.yaml: shared db, cache, and app (build) definitions.
- docker-compose.yaml: refactored to extend the base; strictly
  behavior-preserving (verified with `docker compose config`).
- .devcontainer/: devcontainer.json (Claude Code feature, VS Code extensions,
  forwarded ports), docker-compose.yml (extends base, inline dev env, Postgres
  persisted to a docker-data/devcontainer-db bind mount), and an idempotent
  post-create.sh that runs uv sync, migrations, fixture seeding, and default
  superuser creation, skipping seed steps when the DB is already populated.
- .gitignore / Readme.md: ignore the dev container DB dir and document the
  workflow.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SerCd5rRLrU1TsU8AHCXXQ