### PR TITLE
Fix TypeError comparing content-length header to int in server_proxy

### DIFF
--- a/app/deployments/tests/test_views.py
+++ b/app/deployments/tests/test_views.py
@@ -1,5 +1,8 @@
 import json
+from http import HTTPStatus
+from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from rest_framework.test import APITestCase
 
@@ -26,3 +29,23 @@ class ProxyViewTestCase(APITestCase):
 
         for key in ("columnNames", "columnTypes", "columnUnits", "rows"):
             assert key in data["table"]
+
+    def test_proxy_view_with_content_length_header(self):
+        upstream_response = httpx.Response(
+            200,
+            content=b'{"table": {}}',
+            request=httpx.Request("GET", "http://localhost:8080/tabledap/M01_met_all.json"),
+        )
+        assert "content-length" in upstream_response.headers
+
+        with patch(
+            "deployments.views._proxy_http_client.get",
+            new=AsyncMock(return_value=upstream_response),
+        ):
+            response = self.client.get(
+                "http://localhost:8080/api/servers/1/proxy/tabledap/M01_met_all.json",
+                format="json",
+            )
+
+        assert response.status_code == HTTPStatus.OK
+        assert json.loads(response.content) == {"table": {}}

--- a/app/deployments/views.py
+++ b/app/deployments/views.py
@@ -338,7 +338,8 @@ async def server_proxy(request: HttpRequest, server_id: int) -> HttpResponse | S
         ) from e
 
     # Cache small responses, stream large ones
-    if response.headers.get("content-length", 0) < settings.PROXY_STREAM_THRESHOLD_BYTES:
+    content_length = int(response.headers.get("content-length", 0))
+    if content_length < settings.PROXY_STREAM_THRESHOLD_BYTES:
         return HttpResponse(
             response.content,
             content_type=response.headers.get("content-type"),


### PR DESCRIPTION
httpx returns header values as strings, so the content-length header
must be cast to int before comparing against PROXY_STREAM_THRESHOLD_BYTES.
Previously this only worked when the header was absent (falling back to
the int default), and raised a TypeError whenever upstream responses
included a content-length header.

Fixes #1699